### PR TITLE
Ruby < 1.9 Errors using stored access_token and access_secret

### DIFF
--- a/lib/flickraw.rb
+++ b/lib/flickraw.rb
@@ -20,10 +20,8 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-require 'rubygems'
 require 'net/http'
 require 'json'
-require 'oauth'
 
 module FlickRaw
   VERSION='0.8.4'


### PR DESCRIPTION
Hello, 
I was having a few problems using the flickraw gem with stored access_token and access_secret values.  The test_upload tests were failing in ruby 1.8.6 and 1.8.7, but passing in 1.9.2.  It should pass now.

I was also seeing a space in the USER_AGENT constant in Textmate so I removed that.

Thank you for the great gem,
Dakota Dux
