### PR TITLE
Updating Flickraw oauth_web example to reflect library api change

### DIFF
--- a/examples/web_oauth.rb
+++ b/examples/web_oauth.rb
@@ -34,7 +34,7 @@ def callback
   oauth_token = params[:oauth_token]
   oauth_verifier = params[:oauth_verifier]
 
-  raw_token = flickr.get_oauth_token(request_token['oauth_token'], request_token['oauth_token_secret'], oauth_verifier)
+  raw_token = flickr.get_access_token(request_token['oauth_token'], request_token['oauth_token_secret'], oauth_verifier)
   # raw_token is a hash like this {"user_nsid"=>"92023420%40N00", "oauth_token_secret"=>"XXXXXX", "username"=>"boncey", "fullname"=>"Darren%20Greaves", "oauth_token"=>"XXXXXX"}
   # Use URI.unescape on the nsid and name parameters
 


### PR DESCRIPTION
updating web_oauth example to reflect that get_oauth_token has been replaced with get_access_token.
