### PR TITLE
Add time_diff

### DIFF
--- a/lib/flickraw/api.rb
+++ b/lib/flickraw/api.rb
@@ -142,7 +142,7 @@ module FlickRaw
         args['photo'] = open(file, 'rb')
       end
       
-      oauth_hash_ = {:oauth_token => @access_token}
+      oauth_hash = {:oauth_token => @access_token}
       oauth_hash[:oauth_timestamp] = Time.now.to_i + @time_diff unless @time_diff.nil?
       http_response = @oauth_consumer.post_multipart(method, @access_secret, oauth_hash, args)
       process_response(method, http_response.body)


### PR DESCRIPTION
Ability to modify oauth_timestamp. Usefull for slower uploads. With Typo-fix wich occurred in pull request #53

If you'r upload is to slow, oaut_timestamp will be refused on big files. So you will now be able to set a timestamp in the furture to avoid this problem:

``` ruby
flickr.time_diff = 30*60 # 30 minutes
flickr.upload_photo PHOTO_PATH, :title => "Title", :description => "This is the description"
```

Here my upload of ~190MB

```
user@host ~/ $ time ruby upload 
/home/user/flickraw/lib/flickraw/oauth.rb:156:in `post': timestamp_refused (FlickRaw::OAuthClient::FailedResponse)
    from /home/user/flickraw/lib/flickraw/oauth.rb:96:in `post_multipart'
    from /home/user/flickraw/lib/flickraw/api.rb:147:in `upload_flickr'
    from /home/user/flickraw/lib/flickraw/api.rb:93:in `upload_photo'
    from upload:28:in `<main>'

real    35m25.625s
user    0m0.224s
sys 0m0.467s
user@host ~/ $ vim upload # Setting flickr.time_diff to 30*60
user@host ~/ $ time ruby upload 

real    30m48.949s
user    0m0.231s
sys 0m0.387s
```
