### PR TITLE
Fixes open file leak when a path is sent instead of an I/O stream

### DIFF
--- a/lib/flickraw/api.rb
+++ b/lib/flickraw/api.rb
@@ -137,9 +137,11 @@ module FlickRaw
         args['photo'] = file
       else
         args['photo'] = open(file, 'rb')
+        close_after = true
       end
       
       http_response = @oauth_consumer.post_multipart(method, @access_secret, {:oauth_token => @access_token}, args)
+      args['photo'].close if close_after
       process_response(method, http_response.body)
     end
   end


### PR DESCRIPTION
upload_flickr does not properly close out files leading to an open file leak.
When an I/O stream is passed we probably don't want to close the file as the sender may still want it open, but when a file path is sent we should be closing out the file
