### PR TITLE
Fix #escape to work correctly with non String Objects

### DIFF
--- a/lib/flickraw/oauth.rb
+++ b/lib/flickraw/oauth.rb
@@ -18,8 +18,8 @@ module FlickRaw
       end
 
       def escape(s)
-        encode_value(s).gsub(/[^a-zA-Z0-9\-\.\_\~]/) {
-          $&.unpack("C*").map{|i| sprintf("%%%02X", i) }.join
+        encode_value(s).gsub(/[^a-zA-Z0-9\-\.\_\~]/) { |special|
+          special.unpack("C*").map{|i| sprintf("%%%02X", i) }.join
         }
       end
 


### PR DESCRIPTION
Calling FlickRaw with an ActiveSupport::SafeBuffer as a query parameter instead of a regular string breaks the escape function when the string contains special chars (such as " ").

Using $& is harmful in this case because #gsub in SafeBuffer cannot behave like #gsub in String (cf https://www.ruby-forum.com/topic/198458 ).

This is primarily a SafeBuffer issue, but switching to a classical block variable fixes the issue.
