### PR TITLE
Update README to include url-to-size mapping

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -139,6 +139,17 @@ You can also specify a path to a directory with a number of certifications:
 There are some helpers to build flickr urls :
 
 === url, url_m, url_s, url_t, url_b, url_z, url_q, url_n, url_c, url_o
+ 
+  # url_s : Square
+  # url_q : Large Square
+  # url_t : Thumbnail
+  # url_m : Small
+  # url_n : Small 320
+  # url   : Medium
+  # url_z : Medium 640
+  # url_c : Medium 800
+  # url_b : Large
+  # url_o : Original
 
   info = flickr.photos.getInfo(:photo_id => "3839885270")
   FlickRaw.url_b(info) # => "https://farm3.static.flickr.com/2485/3839885270_6fb8b54e06_b.jpg"


### PR DESCRIPTION
- Add documentation for the various url's and what sizes they correspond to.

Most of the Flickr documentation is pretty straightforward because of naming conventions, but this particular naming scheme doesn't make sense out of context. Add for the sake of convenience.
