### PR TITLE
Skip shared_secret check at initialization

### DIFF
--- a/lib/flickraw/api.rb
+++ b/lib/flickraw/api.rb
@@ -37,8 +37,8 @@ module FlickRaw
     def self.build(methods); methods.each { |m| build_request m } end
 
     def initialize # :nodoc:
-      if FlickRaw.api_key.nil? or FlickRaw.shared_secret.nil?
-        raise FlickrAppNotConfigured.new("No API key or secret defined!")
+      if FlickRaw.api_key.nil?
+        raise FlickrAppNotConfigured.new("No API key defined!")
       end
       @oauth_consumer = OAuthClient.new(FlickRaw.api_key, FlickRaw.shared_secret)
       @oauth_consumer.proxy = FlickRaw.proxy


### PR DESCRIPTION
Open for discussion. I think we can skip the check for the shared secret and if the user wants to upload a photo, he has to handle the `#<FlickRaw::OAuthClient::FailedResponse: token_rejected>` case anyways.
