### PR TITLE
moves the global flickr helper method to a module

### DIFF
--- a/lib/flickraw.rb
+++ b/lib/flickraw.rb
@@ -4,6 +4,7 @@ require 'flickraw/oauth'
 require 'flickraw/request'
 require 'flickraw/response'
 require 'flickraw/api'
+require 'flickraw/helper'
 
 module FlickRaw
   VERSION='0.9.8'
@@ -13,9 +14,3 @@ module FlickRaw
   self.check_certificate = true
 end
 
-# Use this to access the flickr API easily. You can type directly the flickr requests as they are described on the flickr website.
-#  require 'flickraw'
-#
-#  recent_photos = flickr.photos.getRecent
-#  puts recent_photos[0].title
-def flickr; $flickraw ||= FlickRaw::Flickr.new end

--- a/lib/flickraw/helper.rb
+++ b/lib/flickraw/helper.rb
@@ -1,0 +1,15 @@
+module FlickRaw
+
+  # Use this to access the flickr API easily. You can type directly the flickr requests as they are described on the flickr website.
+  #  require 'flickraw'
+  #  include Flickraw::Helper
+  #
+  #  recent_photos = flickr.photos.getRecent
+  #  puts recent_photos[0].title
+  module Helper
+    def flickr
+      @flickraw ||= FlickRaw::Flickr.new
+    end
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,5 +7,6 @@ FlickRaw.api_key = ENV['FLICKRAW_API_KEY']
 FlickRaw.shared_secret = ENV['FLICKRAW_SHARED_SECRET']
 #FlickRaw.secure = false
 
+include FlickRaw::Helper
 flickr.access_token = ENV['FLICKRAW_ACCESS_TOKEN']
 flickr.access_secret = ENV['FLICKRAW_ACCESS_SECRET']


### PR DESCRIPTION
The gem shouldn't declare a global `flickr` method by default. I moved it to a helper module which can be included where necessary.
