### PR TITLE
implement ResponseList#map!

### DIFF
--- a/lib/flickraw/response.rb
+++ b/lib/flickraw/response.rb
@@ -38,11 +38,12 @@ class ResponseList < Response
   include Enumerable
   def initialize(h, t, a); super(h, t); @a = a end
   def [](k); k.is_a?(Integer) ? @a[k] : super(k) end
-  def each; @a.each{|e| yield e} end
+  def each; @a.each { |e| yield e } end
   def to_a; @a end
   def inspect; @a.inspect end
   def size; @a.size end
   def marshal_dump; [@h, @flickr_type, @a] end
+  def map!; @a = @a.map { |e| yield e } end
   alias length size
 end
 


### PR DESCRIPTION
Hello. During the usage of flickraw in my project I found that `ResponseList` doesn't support `map!`:
```
NoMethodError: undefined method `map!' for #<FlickRaw::ResponseList:0x007fe817e772d0>
```
`Enumerable` only includes `map` without bang, so I decided to implement `ResponseList#map!` in this PR to give it more array-like behaviour.