### PR TITLE
Fix and improve code formatting, speed up concatenation

### DIFF
--- a/lib/flickraw.rb
+++ b/lib/flickraw.rb
@@ -9,7 +9,7 @@ require 'flickraw/api'
 module FlickRaw
   VERSION='0.9.9'
   USER_AGENT = "FlickRaw/#{VERSION}"
-  
+
   self.secure = true
   self.check_certificate = true
 end

--- a/lib/flickraw/oauth.rb
+++ b/lib/flickraw/oauth.rb
@@ -13,78 +13,78 @@ module FlickRaw
 
     class << self
       def encode_value(v)
-        v = v.to_s.encode("utf-8").force_encoding("ascii-8bit") if RUBY_VERSION >= "1.9"
+        v = v.to_s.encode('utf-8').force_encoding('ascii-8bit') if RUBY_VERSION >= '1.9'
         v.to_s
       end
 
       def escape(s)
-        encode_value(s).gsub(/[^a-zA-Z0-9\-\.\_\~]/) { |special|
-          special.unpack("C*").map{|i| sprintf("%%%02X", i) }.join
-        }
+        encode_value(s).gsub(/[^a-zA-Z0-9\-\.\_\~]/) do |special|
+          special.unpack("C*").map { |i| sprintf("%%%02X", i) }.join
+        end
       end
 
-      def parse_response(text); Hash[text.split("&").map {|s| s.split("=")}] end
+      def parse_response(text); Hash[text.split('&').map { |s| s.split('=') }] end
 
       def signature_base_string(method, url, params)
-        params_norm = params.map {|k,v| escape(k) + "=" + escape(v)}.sort.join("&")
-        method.to_s.upcase + "&" + escape(url) + "&" + escape(params_norm)
+        params_norm = params.map { |k,v| "#{escape(k)}=#{escape(v)}" }.sort.join('&')
+        "#{method.to_s.upcase}&#{escape(url)}&#{escape(params_norm)}"
       end
-      
+
       def sign_plaintext(method, url, params, token_secret, consumer_secret)
-        escape(consumer_secret) + "&" + escape(token_secret)
+        "#{escape(consumer_secret)}&#{escape(token_secret)}"
       end
-        
+
       def sign_rsa_sha1(method, url, params, token_secret, consumer_secret)
         text = signature_base_string(method, url, params)
         key = OpenSSL::PKey::RSA.new(consumer_secret)
         digest = OpenSSL::Digest::SHA1.new
         [key.sign(digest, text)].pack('m0').gsub(/\n$/,'')
       end
-            
+
       def sign_hmac_sha1(method, url, params, token_secret, consumer_secret)
         text = signature_base_string(method, url, params)
-        key = escape(consumer_secret) + "&" + escape(token_secret)
+        key = "#{escape(consumer_secret)}&#{escape(token_secret)}"
         digest = OpenSSL::Digest::SHA1.new
         [OpenSSL::HMAC.digest(digest, key, text)].pack('m0').gsub(/\n$/,'')
       end
-    
+
       def gen_timestamp; Time.now.to_i end
       def gen_nonce; [OpenSSL::Random.random_bytes(32)].pack('m0').gsub(/\n$/,'') end
       def gen_default_params
-        { :oauth_version => "1.0", :oauth_signature_method => "HMAC-SHA1",
+        { :oauth_version => "1.0", :oauth_signature_method => 'HMAC-SHA1',
           :oauth_nonce => gen_nonce, :oauth_timestamp => gen_timestamp }
       end
-    
+
       def authorization_header(url, params)
-        params_norm = params.map {|k,v| %(#{escape(k)}="#{escape(v)}")}.sort.join(", ")
+        params_norm = params.map { |k, v| %(#{escape(k)}="#{escape(v)}")}.sort.join(', ')
         %(OAuth realm="#{url.to_s}", #{params_norm})
       end
     end
-    
+
     attr_accessor :user_agent
     attr_reader :proxy
     attr_accessor :check_certificate
     attr_accessor :ca_file
     attr_accessor :ca_path
     def proxy=(url); @proxy = URI.parse(url || '') end
-    
+
     def initialize(consumer_key, consumer_secret)
       @consumer_key, @consumer_secret = consumer_key, consumer_secret
       self.proxy = nil
     end
 
     def request_token(url, oauth_params = {})
-      r = post_form(url, nil, {:oauth_callback => "oob"}.merge(oauth_params))
+      r = post_form(url, nil, {:oauth_callback => 'oob'}.merge(oauth_params))
       OAuthClient.parse_response(r.body)
     end
-    
+
     def authorize_url(url, oauth_params = {})
-      params_norm = oauth_params.map {|k,v| OAuthClient.escape(k) + "=" + OAuthClient.escape(v)}.sort.join("&")
-      url =  URI.parse(url)
-      url.query = url.query ? url.query + "&" + params_norm : params_norm
+      params_norm = oauth_params.map { |k,v| "#{OAuthClient.escape(k)}=#{OAuthClient.escape(v)}" }.sort.join('&')
+      url = URI.parse(url)
+      url.query = url.query ? "#{url.query}&#{params_norm}" : params_norm
       url.to_s
     end
-    
+
     def access_token(url, token_secret, oauth_params = {})
       r = post_form(url, token_secret, oauth_params)
       OAuthClient.parse_response(r.body)
@@ -92,32 +92,32 @@ module FlickRaw
 
     def post_form(url, token_secret, oauth_params = {}, params = {})
       encoded_params = Hash[*params.map {|k,v| [OAuthClient.encode_value(k), OAuthClient.encode_value(v)]}.flatten]
-      post(url, token_secret, oauth_params, params) {|request| request.form_data = encoded_params}
+      post(url, token_secret, oauth_params, params) { |request| request.form_data = encoded_params }
     end
-    
+
     def post_multipart(url, token_secret, oauth_params = {}, params = {})
       post(url, token_secret, oauth_params, params) {|request|
         boundary = "FlickRaw#{OAuthClient.gen_nonce}"
         request['Content-type'] = "multipart/form-data, boundary=#{boundary}"
 
         request.body = ''
-        params.each { |k, v|
+        params.each do |k, v|
           if v.respond_to? :read
             basename = File.basename(v.path.to_s) if v.respond_to? :path
             basename ||= File.basename(v.base_uri.to_s) if v.respond_to? :base_uri
             basename ||= "unknown"
             request.body << "--#{boundary}\r\n" <<
-              "Content-Disposition: form-data; name=\"#{OAuthClient.encode_value(k)}\"; filename=\"#{OAuthClient.encode_value(basename)}\"\r\n" <<
-              "Content-Transfer-Encoding: binary\r\n" <<
-              "Content-Type: image/jpeg\r\n\r\n" <<
-              v.read << "\r\n"
+            "Content-Disposition: form-data; name=\"#{OAuthClient.encode_value(k)}\"; filename=\"#{OAuthClient.encode_value(basename)}\"\r\n" <<
+            "Content-Transfer-Encoding: binary\r\n" <<
+            "Content-Type: image/jpeg\r\n\r\n" <<
+            v.read << "\r\n"
           else
             request.body << "--#{boundary}\r\n" <<
-              "Content-Disposition: form-data; name=\"#{OAuthClient.encode_value(k)}\"\r\n\r\n" <<
-              "#{OAuthClient.encode_value(v)}\r\n"
+            "Content-Disposition: form-data; name=\"#{OAuthClient.encode_value(k)}\"\r\n\r\n" <<
+            "#{OAuthClient.encode_value(v)}\r\n"
           end
-        }
-        
+        end
+
         request.body << "--#{boundary}--"
       }
     end
@@ -125,11 +125,11 @@ module FlickRaw
     private
     def sign(method, url, params, token_secret = nil)
       case params[:oauth_signature_method]
-      when "HMAC-SHA1"
+      when 'HMAC-SHA1'
         OAuthClient.sign_hmac_sha1(method, url, params, token_secret, @consumer_secret)
-      when "RSA-SHA1"
+      when 'RSA-SHA1'
         OAuthClient.sign_rsa_sha1(method, url, params, token_secret, @consumer_secret)
-      when "PLAINTEXT"
+      when 'PLAINTEXT'
         OAuthClient.sign_plaintext(method, url, params, token_secret, @consumer_secret)
       else
         raise UnknownSignatureMethod, params[:oauth_signature_method]
@@ -140,9 +140,9 @@ module FlickRaw
       url = URI.parse(url)
       default_oauth_params = OAuthClient.gen_default_params
       default_oauth_params[:oauth_consumer_key] = @consumer_key
-      default_oauth_params[:oauth_signature_method] = "PLAINTEXT" if url.scheme == 'https'
+      default_oauth_params[:oauth_signature_method] = 'PLAINTEXT' if url.scheme == 'https'
       oauth_params = default_oauth_params.merge(oauth_params)
-      params_signed = params.reject {|k,v| v.respond_to? :read}.merge(oauth_params)
+      params_signed = params.reject { |k,v| v.respond_to? :read }.merge(oauth_params)
       oauth_params[:oauth_signature] = sign(:post, url, params_signed, token_secret)
 
       http = Net::HTTP.new(url.host, url.port, @proxy.host, @proxy.port, @proxy.user, @proxy.password)
@@ -150,18 +150,17 @@ module FlickRaw
       http.verify_mode = (@check_certificate ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE)
       http.ca_file = @ca_file
       http.ca_path = @ca_path
-      r = http.start {|agent|
+      r = http.start do |agent|
         request = Net::HTTP::Post.new(url.path)
         request['User-Agent'] = @user_agent if @user_agent
         request['Authorization'] = OAuthClient.authorization_header(url, oauth_params)
 
         yield request
         agent.request(request)
-      }
-      
+      end
+
       raise FailedResponse.new(r.body) if r.is_a? Net::HTTPClientError
       r
     end
   end
-
 end

--- a/lib/flickraw/request.rb
+++ b/lib/flickraw/request.rb
@@ -1,50 +1,49 @@
 module FlickRaw
-class Request
-  def initialize(flickr = nil) # :nodoc:
-    @flickr = flickr
+  class Request
+    def initialize(flickr = nil) # :nodoc:
+      @flickr = flickr
 
-    self.class.flickr_objects.each {|name|
-      klass = self.class.const_get name.capitalize
-      instance_variable_set "@#{name}", klass.new(@flickr)
-    }
-  end
+      self.class.flickr_objects.each {|name|
+        klass = self.class.const_get name.capitalize
+        instance_variable_set "@#{name}", klass.new(@flickr)
+      }
+    end
 
-  def self.build_request(req) # :nodoc:
-    method_nesting = req.split '.'
-    raise "'#{@name}' : Method name mismatch" if method_nesting.shift != request_name.split('.').last
+    def self.build_request(req) # :nodoc:
+      method_nesting = req.split '.'
+      raise "'#{@name}' : Method name mismatch" if method_nesting.shift != request_name.split('.').last
 
-    if method_nesting.size > 1
-      name = method_nesting.first
-      class_name = name.capitalize
-      if flickr_objects.include? name
-        klass = const_get(class_name)
+      if method_nesting.size > 1
+        name = method_nesting.first
+        class_name = name.capitalize
+        if flickr_objects.include? name
+          klass = const_get(class_name)
+        else
+          klass = Class.new Request
+          const_set(class_name, klass)
+          attr_reader name
+          flickr_objects << name
+        end
+
+        klass.build_request method_nesting.join('.')
       else
-        klass = Class.new Request
-        const_set(class_name, klass)
-        attr_reader name
-        flickr_objects << name
-      end
-
-      klass.build_request method_nesting.join('.')
-    else
-      req = method_nesting.first
-      module_eval %{
+        req = method_nesting.first
+        module_eval %{
         def #{req}(*args, &block)
           @flickr.call("#{request_name}.#{req}", *args, &block)
         end
-      } if Util.safe_for_eval?(req)
-      flickr_methods << req
+        } if Util.safe_for_eval?(req)
+        flickr_methods << req
+      end
     end
+
+    # List the flickr subobjects of this object
+    def self.flickr_objects; @flickr_objects ||= [] end
+
+    # List the flickr methods of this object
+    def self.flickr_methods; @flickr_methods ||= [] end
+
+    # Returns the prefix of the request corresponding to this class.
+    def self.request_name; name.downcase.gsub(/::/, '.').sub(/[^\.]+\./, '') end
   end
-
-  # List the flickr subobjects of this object
-  def self.flickr_objects; @flickr_objects ||= [] end
-
-  # List the flickr methods of this object
-  def self.flickr_methods; @flickr_methods ||= [] end
-
-  # Returns the prefix of the request corresponding to this class.
-  def self.request_name; name.downcase.gsub(/::/, '.').sub(/[^\.]+\./, '') end
-end
-
 end

--- a/lib/flickraw/response.rb
+++ b/lib/flickraw/response.rb
@@ -1,58 +1,57 @@
 module FlickRaw
-class Response
-  def self.build(h, type) # :nodoc:
-    if h.is_a? Response
-      h
-    elsif type =~ /s$/ and (a = h[$`]).is_a? Array
-      ResponseList.new(h, type, a.collect {|e| Response.build(e, $`)})
-    elsif h.keys == ["_content"]
-      h["_content"]
-    else
-      Response.new(h, type)
+  class Response
+    def self.build(h, type) # :nodoc:
+      if h.is_a? Response
+        h
+      elsif type =~ /s$/ and (a = h[$`]).is_a? Array
+        ResponseList.new(h, type, a.collect { |e| Response.build(e, $`) })
+      elsif h.keys == ['_content']
+        h['_content']
+      else
+        Response.new(h, type)
+      end
+    end
+
+    attr_reader :flickr_type
+    def initialize(h, type) # :nodoc:
+      @flickr_type, @h = type, {}
+      methods = 'class << self;'
+      h.each do |k, v|
+        @h[k] = case v
+                when Hash  then Response.build(v, k)
+                when Array then v.collect { |e| Response.build(e, k) }
+                else v
+                end
+        methods << "def #{k}; @h['#{k}'] end;" if Util.safe_for_eval?(k)
+      }
+      eval methods << 'end'
+    end
+    def [](k); @h[k] end
+    def to_s; @h['_content'] || super end
+    def inspect; @h.inspect end
+    def to_hash; @h end
+    def marshal_dump; [@h, @flickr_type] end
+    def marshal_load(data); initialize(*data) end
+  end
+
+  class ResponseList < Response
+    include Enumerable
+    def initialize(h, t, a); super(h, t); @a = a end
+    def [](k); k.is_a?(Integer) ? @a[k] : super(k) end
+    def each; @a.each { |e| yield e } end
+    def to_a; @a end
+    def inspect; @a.inspect end
+    def size; @a.size end
+    def marshal_dump; [@h, @flickr_type, @a] end
+    alias length size
+  end
+
+  class FailedResponse < Error
+    attr_reader :code
+    alias :msg :message
+    def initialize(msg, code, req)
+      @code = code
+      super("'#{req}' - #{msg}")
     end
   end
-
-  attr_reader :flickr_type
-  def initialize(h, type) # :nodoc:
-    @flickr_type, @h = type, {}
-    methods = "class << self;"
-    h.each {|k,v|
-      @h[k] = case v
-        when Hash  then Response.build(v, k)
-        when Array then v.collect {|e| Response.build(e, k)}
-        else v
-      end
-      methods << "def #{k}; @h['#{k}'] end;" if Util.safe_for_eval?(k)
-    }
-    eval methods << "end"
-  end
-  def [](k); @h[k] end
-  def to_s; @h["_content"] || super end
-  def inspect; @h.inspect end
-  def to_hash; @h end
-  def marshal_dump; [@h, @flickr_type] end
-  def marshal_load(data); initialize(*data) end
-end
-
-class ResponseList < Response
-  include Enumerable
-  def initialize(h, t, a); super(h, t); @a = a end
-  def [](k); k.is_a?(Integer) ? @a[k] : super(k) end
-  def each; @a.each{|e| yield e} end
-  def to_a; @a end
-  def inspect; @a.inspect end
-  def size; @a.size end
-  def marshal_dump; [@h, @flickr_type, @a] end
-  alias length size
-end
-
-class FailedResponse < Error
-  attr_reader :code
-  alias :msg :message
-  def initialize(msg, code, req)
-    @code = code
-    super("'#{req}' - #{msg}")
-  end
-end
-
 end

--- a/lib/flickraw/util.rb
+++ b/lib/flickraw/util.rb
@@ -9,6 +9,5 @@ module FlickRaw
     def safe_for_eval?(string)
       string == sanitize(string)
     end
-
   end
 end


### PR DESCRIPTION
Hello. Last time when I worked on a PR for this gem I noticed some problems in code formatting. I think that it's better to keep code closer to the [style guide](https://github.com/bbatsov/ruby-style-guide) popular in ruby community.

In this PR code has been cleaned to match the style guide, also strings concatenation has been changed to interpolation because it works faster.