### PR TITLE
Use the correct endpoint for uploads

### DIFF
--- a/lib/flickraw.rb
+++ b/lib/flickraw.rb
@@ -11,14 +11,15 @@ module FlickRaw
   USER_AGENT = "FlickRaw/#{VERSION}"
 
   END_POINT                  = 'https://api.flickr.com/services'.freeze
+  UPLOAD_END_POINT           = 'https://up.flickr.com/services'.freeze
 
   FLICKR_OAUTH_REQUEST_TOKEN = (END_POINT + '/oauth/request_token').freeze
   FLICKR_OAUTH_AUTHORIZE     = (END_POINT + '/oauth/authorize').freeze
   FLICKR_OAUTH_ACCESS_TOKEN  = (END_POINT + '/oauth/access_token').freeze
 
   REST_PATH                  = (END_POINT + '/rest/').freeze
-  UPLOAD_PATH                = (END_POINT + '/upload/').freeze
-  REPLACE_PATH               = (END_POINT + '/replace/').freeze
+  UPLOAD_PATH                = (UPLOAD_END_POINT + '/upload/').freeze
+  REPLACE_PATH               = (UPLOAD_END_POINT + '/replace/').freeze
 
   PHOTO_SOURCE_URL           = 'https://farm%s.staticflickr.com/%s/%s_%s%s.%s'.freeze
   URL_PROFILE                = 'https://www.flickr.com/people/'.freeze


### PR DESCRIPTION
According to the Flickr API docs, [upload](https://www.flickr.com/services/api/upload.api.html) and [replace](https://www.flickr.com/services/api/replace.api.html) API requests should be made to the `https://up.flickr.com/services` endpoint. They're currently being made to `https://api.flickr.com/services`, which worked until very recently, but something must have changed with the recent [migration to AWS](https://blog.flickr.net/en/2019/05/08/planned-maintenance-and-flickr-downtime/) and now upload & replace only work when made against up.flickr.com.

This PR switches upload & replace to that endpoint. This addresses #110.