### PR TITLE
Handle responses that contain arrays of simple strings

### DIFF
--- a/lib/flickraw/response.rb
+++ b/lib/flickraw/response.rb
@@ -1,7 +1,7 @@
 module FlickRaw
   class Response
     def self.build(h, type) # :nodoc:
-      if h.is_a? Response
+      if h.is_a?(Response) || h.is_a?(String)
         h
       elsif type =~ /s$/ and (a = h[$`]).is_a? Array
         ResponseList.new(h, type, a.collect { |e| Response.build(e, $`) })


### PR DESCRIPTION
At some point in the past couple of years, Flickr appears to have updated the `flickr.photos.getInfo` response to include information about the photo owner's "gift" eligibility. The relevant section of the JSON response looks like:

```
{
  "nsid"=>"41650587@N02",
  "username"=>"ruby_flickraw",
  "realname"=>"Flickraw",
  "location"=>"",
  "iconserver"=>"0",
  "iconfarm"=>0,
  "path_alias"=>nil,
  "gift"=>
  {
    "gift_eligible"=>true,
    "eligible_durations"=>["year", "month", "week"],
    "new_flow"=>true
  }
}
```

The "eligible_durations" part of this response contains a simple list of strings, which is something that `FlickRaw::Response` wasn't designed to handle. When parsing the JSON, `FlickRaw::Response` was trying to treat each element of the "eligible_durations" array as a Hash for further processing.

This patch updates `FlickRaw::Response.build` to recognize these simple string and not try to treat their elements as hashes.